### PR TITLE
not sure how to get around custome behaviour here for python2 and pyt…

### DIFF
--- a/CoderPad/serve_coderpad.py
+++ b/CoderPad/serve_coderpad.py
@@ -41,7 +41,11 @@ def main():
     print("Serving on %s:%s"%(config['host'],config['port']))
     print("NOTE that you can change your config settings at %s"%CONFIG_FILE)
     print("NOTE that your can run this with the `--create-admin` flag to create a new admin user")
-    socketio.run(app,config['host'],config['port'])
+    if sys.version_info > (3,):
+        socketio.run(app, config['host'], config['port'])
+    else:
+        socketio.run(app,config['host'].encode('latin1'),config['port'].encode('latin1'))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
…hon3, eventlet expects a str in python3 and does not expect unicode in python2